### PR TITLE
Look for column that is unique when trying to match it

### DIFF
--- a/lib/shoulda/matchers/active_record/have_db_index_matcher.rb
+++ b/lib/shoulda/matchers/active_record/have_db_index_matcher.rb
@@ -124,6 +124,10 @@ module Shoulda
         end
 
         def matched_index
+          if @options.key?(:unique)
+            matched = indexes.detect { |each| each.columns == @columns && each.unique }
+            return matched if matched
+          end
           indexes.detect { |each| each.columns == @columns }
         end
 


### PR DESCRIPTION
When looking for a unique index, first look for an index that has the correct columns _and_ is unique. This way, if there is more than one index, the one that is most similar to the one we're trying to match is selected.